### PR TITLE
Trusted workspace for CVE-2022-24765 changes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env sh
+# Trust workspace
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
 cloc $(git rev-parse HEAD) | tee -a cloc.txt


### PR DESCRIPTION
Running [djdefi/cloc-action@3](https://github.com/djdefi/cloc-action/releases/tag/3) or latest (commit 6c53ec443bd8edec7b55734c0f5ba812d3d44fb4) fails due security updates to git for CVE-2022-24765 (see https://github.com/actions/checkout/issues/766)

When the cloc container runs the following error is seen:
```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```