### PR TITLE
Allow additional arguments to be passed to cloc

### DIFF
--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -20,9 +20,14 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
 
-    # Runs djdefi/cloc-action@master
+    # Runs djdefi/cloc-action@main
     - name: Count Lines of Code (cloc)
       uses: djdefi/cloc-action@main
+    
+    - name: Count Lines of Code with additional options
+      uses: djdefi/cloc-action@main
+      with:
+          options: --exclude-lang=YML --md --report-file=cloc.md
     
     #- name: Upload cloc output as a build artifact
     #  uses: actions/upload-artifact@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM alpine:3.18
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/entrypoint.sh"]
 
 RUN apk add --no-cache --update cloc \
     dumb-init \
     git 
-    
+
 COPY entrypoint.sh /

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,18 @@
 # action.yml
 name: 'Count Lines of Code (cloc)'
 description: 'Count Lines of Code with https://github.com/AlDanial/cloc'
+inputs:
+  options:
+    description: 'Additional options to pass to cloc'
+    required: false
+    default: ''
 
 runs:
   using: 'docker'
   image: 'Dockerfile'
- 
+  args:
+    - ${{ inputs.options }}
+
 branding:
   icon: 'code'  
   color: 'blue'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 # Trust workspace
 git config --global --add safe.directory "$GITHUB_WORKSPACE"
-cloc $(git rev-parse HEAD) | tee -a cloc.txt
+cloc $(git rev-parse HEAD) $1 | tee -a cloc.txt


### PR DESCRIPTION
This PR would allow additional arguments to be passed to cloc using the `options` argument. In a workflow, this might look like:
```yaml
      - name: Count Lines of Code
        uses: djdefi/cloc-action@5.1
        with:
          options: --exclude-lang=HTML --md --report-file=cloc.md
```

I modified the ENTRYPOINT to allow the optional arguments to be passed to the shell script. I am not familiar with `dumb-init` so I hope this was the correct way to extend the entrypoint.